### PR TITLE
Ph/78 round functionality

### DIFF
--- a/packages/expression_language/lib/src/expressions/expressions.dart
+++ b/packages/expression_language/lib/src/expressions/expressions.dart
@@ -537,25 +537,54 @@ class ListCountFunctionExpression<T> extends Expression<int> {
   }
 }
 
-class RoundFunctionWithRoundingModeExpression extends Expression<Number> {
+class RoundFunctionIntRoundingModeExpression extends Expression<Number> {
   final Expression<Number> value;
   final Expression<Integer> precision;
   final Expression<Integer> roundingMode;
 
-  RoundFunctionWithRoundingModeExpression(this.value, this.precision, this.roundingMode);
+  RoundFunctionIntRoundingModeExpression(
+      this.value, this.precision, this.roundingMode);
 
   @override
   void accept(ExpressionVisitor visitor) {
-    visitor.visitRoundFunctionWithRoundingMode(this);
+    visitor.visitRoundFunctionIntRoundingMode(this);
   }
 
   @override
   Number evaluate() {
     int roundingModeInt = roundingMode.evaluate().value;
-    if ((roundingModeInt >= RoundingMode.values.length) || (roundingModeInt < 0))
-      throw InvalidParameter("Rounding mode has to be integer in range [0,${RoundingMode.values.length-1}");
+    if ((roundingModeInt >= RoundingMode.values.length) ||
+        (roundingModeInt < 0))
+      throw InvalidParameter(
+          "Rounding mode has to be integer in range [0,${RoundingMode.values.length - 1}");
     return value.evaluate().roundWithPrecision(precision.evaluate().value,
         RoundingMode.values[roundingMode.evaluate().value]);
+  }
+}
+
+class RoundFunctionStringRoundingModeExpression extends Expression<Number> {
+  final Expression<Number> value;
+  final Expression<Integer> precision;
+  final Expression<String> roundingMode;
+
+  RoundFunctionStringRoundingModeExpression(
+      this.value, this.precision, this.roundingMode);
+
+  @override
+  void accept(ExpressionVisitor visitor) {
+    visitor.visitRoundFunctionStringRoundingMode(this);
+  }
+
+  @override
+  Number evaluate() {
+    String roundingModeString = roundingMode.evaluate();
+    String nameOfEnum = RoundingMode.nearest_even.toString().split('.').first;
+    RoundingMode mode = RoundingMode.values.firstWhere(
+        (e) => e.toString() == nameOfEnum + '.' + roundingModeString,
+        orElse: () => throw InvalidParameter("Rounding mode $roundingModeString does not exist"));
+    return value
+        .evaluate()
+        .roundWithPrecision(precision.evaluate().value, mode);
   }
 }
 
@@ -572,7 +601,9 @@ class RoundFunctionExpression extends Expression<Number> {
 
   @override
   Number evaluate() {
-    return value.evaluate().roundWithPrecision(precision.evaluate().toInteger().value);
+    return value
+        .evaluate()
+        .roundWithPrecision(precision.evaluate().toInteger().value);
   }
 }
 

--- a/packages/expression_language/lib/src/expressions/expressions.dart
+++ b/packages/expression_language/lib/src/expressions/expressions.dart
@@ -537,12 +537,33 @@ class ListCountFunctionExpression<T> extends Expression<int> {
   }
 }
 
-class RoundFunctionExpression extends Expression<Number> {
+class RoundFunctionWithRoundingModeExpression extends Expression<Number> {
   final Expression<Number> value;
   final Expression<Integer> precision;
   final Expression<Integer> roundingMode;
 
-  RoundFunctionExpression(this.value, this.precision, this.roundingMode);
+  RoundFunctionWithRoundingModeExpression(this.value, this.precision, this.roundingMode);
+
+  @override
+  void accept(ExpressionVisitor visitor) {
+    visitor.visitRoundFunctionWithRoundingMode(this);
+  }
+
+  @override
+  Number evaluate() {
+    int roundingModeInt = roundingMode.evaluate().value;
+    if ((roundingModeInt >= RoundingMode.values.length) || (roundingModeInt < 0))
+      throw InvalidParameter("Rounding mode has to be integer in range [0,${RoundingMode.values.length-1}");
+    return value.evaluate().roundWithPrecision(precision.evaluate().value,
+        RoundingMode.values[roundingMode.evaluate().value]);
+  }
+}
+
+class RoundFunctionExpression extends Expression<Number> {
+  final Expression<Number> value;
+  final Expression<Number> precision;
+
+  RoundFunctionExpression(this.value, this.precision);
 
   @override
   void accept(ExpressionVisitor visitor) {
@@ -551,11 +572,7 @@ class RoundFunctionExpression extends Expression<Number> {
 
   @override
   Number evaluate() {
-    int roundingModeInt = roundingMode.evaluate().value;
-    if ((roundingModeInt > 4) || (roundingModeInt < 0))
-      throw InvalidParameter("Rounding mode has to be integer in range [0,4]");
-    return value.evaluate().preciseRound(precision.evaluate().value,
-        RoundingMode.values[roundingMode.evaluate().value]);
+    return value.evaluate().roundWithPrecision(precision.evaluate().toInteger().value);
   }
 }
 

--- a/packages/expression_language/lib/src/expressions/expressions.dart
+++ b/packages/expression_language/lib/src/expressions/expressions.dart
@@ -578,7 +578,7 @@ class RoundFunctionStringRoundingModeExpression extends Expression<Number> {
   @override
   Number evaluate() {
     String roundingModeString = roundingMode.evaluate();
-    String nameOfEnum = RoundingMode.nearest_even.toString().split('.').first;
+    String nameOfEnum = RoundingMode.nearestEven.toString().split('.').first;
     RoundingMode mode = RoundingMode.values.firstWhere(
         (e) => e.toString() == nameOfEnum + '.' + roundingModeString,
         orElse: () => throw InvalidParameter("Rounding mode $roundingModeString does not exist"));

--- a/packages/expression_language/lib/src/expressions/expressions.dart
+++ b/packages/expression_language/lib/src/expressions/expressions.dart
@@ -17,12 +17,12 @@ class MutableExpression<T> extends Expression<T> {
   MutableExpression(this.value);
 
   @override
-  T evaluate() {                            
+  T evaluate() {
     return value;
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return value.runtimeType;
   }
 
@@ -38,12 +38,12 @@ class ImmutableExpression<T> extends Expression<T> {
   ImmutableExpression(this.value);
 
   @override
-  T evaluate() {                            
+  T evaluate() {
     return value;
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return value.runtimeType;
   }
 
@@ -91,7 +91,7 @@ class PlusNumberExpression extends Expression<Number> {
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return getTypeOfNumberExpression(left.getType(), right.getType());
   }
 
@@ -140,7 +140,7 @@ class MinusNumberExpression extends Expression<Number> {
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return getTypeOfNumberExpression(left.getType(), right.getType());
   }
 
@@ -149,7 +149,6 @@ class MinusNumberExpression extends Expression<Number> {
     visitor.visitMinusNumber(this);
   }
 }
-
 
 class NegateNumberExpression extends Expression<Number> {
   final Expression<Number> value;
@@ -189,7 +188,7 @@ class MultiplyExpression extends Expression<Number> {
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return getTypeOfNumberExpression(left.getType(), right.getType());
   }
 
@@ -254,7 +253,6 @@ class NegateBoolExpression extends Expression<bool> {
   }
 }
 
-
 class EqualNumberExpression extends Expression<bool> {
   final Expression<Number> left;
   final Expression<Number> right;
@@ -305,7 +303,6 @@ class EqualStringExpression extends Expression<bool> {
     visitor.visitEqualString(this);
   }
 }
-
 
 class NotEqualNumberExpression extends Expression<bool> {
   final Expression<Number> left;
@@ -358,7 +355,6 @@ class NotEqualStringExpression extends Expression<bool> {
   }
 }
 
-
 class LessThanExpression extends Expression<bool> {
   final Expression<Number> left;
   final Expression<Number> right;
@@ -405,7 +401,8 @@ class DelegateExpression<T> extends Expression<T> {
   }
 
   ExpressionProvider<T> getExpressionProvider<T>() {
-    return expressionProvider as ExpressionProvider<T>; //Doesn't work without as, probably compiler error
+    return expressionProvider as ExpressionProvider<
+        T>; //Doesn't work without as, probably compiler error
   }
 
   @override
@@ -479,12 +476,15 @@ class DivisionExpression extends Expression<Number> {
   Number evaluate() {
     Number rightValue = right.evaluate();
     Decimal epsilon = Decimal.parse("1e-15");
-    if(rightValue.abs() < epsilon) throw DivideByZeroException("Division by zero");
-    return (left.getType() == Integer && right.getType() == Integer) ? left.evaluate() ~/ right.evaluate() : left.evaluate() / right.evaluate();
+    if (rightValue.abs() < epsilon)
+      throw DivideByZeroException("Division by zero");
+    return (left.getType() == Integer && right.getType() == Integer)
+        ? left.evaluate() ~/ right.evaluate()
+        : left.evaluate() / right.evaluate();
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return getTypeOfNumberExpression(left.getType(), right.getType());
   }
 
@@ -511,7 +511,7 @@ class ModuloExpression extends Expression<Number> {
   }
 
   @override
-  Type getType(){
+  Type getType() {
     return getTypeOfNumberExpression(left.getType(), right.getType());
   }
 
@@ -520,7 +520,6 @@ class ModuloExpression extends Expression<Number> {
     visitor.visitModulo(this);
   }
 }
-
 
 class ListCountFunctionExpression<T> extends Expression<int> {
   final Expression<List<T>> value;
@@ -538,8 +537,31 @@ class ListCountFunctionExpression<T> extends Expression<int> {
   }
 }
 
-Type getTypeOfNumberExpression(Type left, Type right){
-  if(left != right){ //One of them has to be decimal => whole expr is decimal
+class RoundFunctionExpression extends Expression<Number> {
+  final Expression<Number> value;
+  final Expression<Integer> precision;
+  final Expression<Integer> roundingMode;
+
+  RoundFunctionExpression(this.value, this.precision, this.roundingMode);
+
+  @override
+  void accept(ExpressionVisitor visitor) {
+    visitor.visitRoundFunction(this);
+  }
+
+  @override
+  Number evaluate() {
+    int roundingModeInt = roundingMode.evaluate().value;
+    if ((roundingModeInt > 4) || (roundingModeInt < 0))
+      throw InvalidParameter("Rounding mode has to be integer in range [0,4]");
+    return value.evaluate().preciseRound(precision.evaluate().value,
+        RoundingMode.values[roundingMode.evaluate().value]);
+  }
+}
+
+Type getTypeOfNumberExpression(Type left, Type right) {
+  if (left != right) {
+    //One of them has to be decimal => whole expr is decimal
     return Decimal;
   }
   return left;

--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -179,12 +179,13 @@ class Decimal extends Number {
           return _roundDown(precision);
       }
       return null; //to suppress warning
+    } else {
+      return toInteger().roundWithPrecision(precision);
     }
-    else return toInteger().roundWithPrecision(precision);
   }
 
   Number _roundTowardsZero(int precision) {
-    final Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10, precision));
     Number tempNumber = this * multiplier;
     tempNumber =
         (tempNumber >= Integer(0)) ? tempNumber.floor() : tempNumber.ceil();
@@ -192,7 +193,7 @@ class Decimal extends Number {
   }
 
   Number _roundFromZero(int precision) {
-    final Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10, precision));
     Number tempNumber = this * multiplier;
     tempNumber =
         (tempNumber >= Integer(0)) ? tempNumber.ceil() : tempNumber.floor();
@@ -200,31 +201,33 @@ class Decimal extends Number {
   }
 
   Number _roundUp(int precision) {
-    final Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10, precision));
     return (this * multiplier).ceil() / multiplier;
   }
 
   Number _roundDown(int precision) {
-    final Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10, precision));
     return (this * multiplier).floor() / multiplier;
   }
 
-  Number _roundNearestEven(int precision){
-    final Integer multiplier = Integer(pow(10,precision));
+  Number _roundNearestEven(int precision) {
+    final Integer multiplier = Integer(pow(10, precision));
     final Number tempNumber = this * multiplier;
     final String integerPart = tempNumber.toInt().toString();
-    var parts = tempNumber.toString().split('.'); 
+    var parts = tempNumber.toString().split('.');
     final String decimalPart = (parts.length == 2) ? parts[1] : "";
 
-    if(decimalPart.length > 0 && decimalPart[0] == '5'){
-      int lastDigit = int.tryParse(integerPart[integerPart.length-1]);
-      return (lastDigit % 2 == 0) ? _roundTowardsZero(precision) : _roundFromZero(precision);
-    }
-    else return _roundNearestFromZero(precision);
+    if (decimalPart.length > 0 && decimalPart[0] == '5') {
+      int lastDigit = int.tryParse(integerPart[integerPart.length - 1]);
+      return (lastDigit % 2 == 0)
+          ? _roundTowardsZero(precision)
+          : _roundFromZero(precision);
+    } else
+      return _roundNearestFromZero(precision);
   }
 
-  Number _roundNearestFromZero(int precision){
-    final Integer multiplier = Integer(pow(10,precision));
+  Number _roundNearestFromZero(int precision) {
+    final Integer multiplier = Integer(pow(10, precision));
     return (this * multiplier).round() / multiplier;
   }
 }

--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -162,16 +162,16 @@ class Decimal extends Number {
   Integer truncate() => Decimal._fromRational(_rational.truncate()).toInteger();
 
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.nearest_even]) {
+      [RoundingMode mode = RoundingMode.nearestEven]) {
     if (precision >= 0) {
       switch (mode) {
-        case RoundingMode.nearest_even:
+        case RoundingMode.nearestEven:
           return _roundNearestEven(precision);
-        case RoundingMode.nearest_from_zero:
+        case RoundingMode.nearestFromZero:
           return _roundNearestFromZero(precision);
-        case RoundingMode.towards_zero:
+        case RoundingMode.towardsZero:
           return _roundTowardsZero(precision);
-        case RoundingMode.from_zero:
+        case RoundingMode.fromZero:
           return _roundFromZero(precision);
         case RoundingMode.up:
           return _roundUp(precision);

--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -161,7 +161,7 @@ class Decimal extends Number {
   @override
   Integer truncate() => Decimal._fromRational(_rational.truncate()).toInteger();
 
-  Number preciseRound(int precision,
+  Number roundWithPrecision(int precision,
       [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
     if (precision >= 0) {
       switch (mode) {
@@ -171,6 +171,8 @@ class Decimal extends Number {
           return _roundNearestFromZero(precision);
         case RoundingMode.TOWARDS_ZERO:
           return _roundTowardsZero(precision);
+        case RoundingMode.FROM_ZERO:
+          return _roundFromZero(precision);
         case RoundingMode.UP:
           return _roundUp(precision);
         case RoundingMode.DOWN:
@@ -178,11 +180,11 @@ class Decimal extends Number {
       }
       return null; //to suppress warning
     }
-    else return toInteger().preciseRound(precision);
+    else return toInteger().roundWithPrecision(precision);
   }
 
   Number _roundTowardsZero(int precision) {
-    Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10,precision));
     Number tempNumber = this * multiplier;
     tempNumber =
         (tempNumber >= Integer(0)) ? tempNumber.floor() : tempNumber.ceil();
@@ -190,7 +192,7 @@ class Decimal extends Number {
   }
 
   Number _roundFromZero(int precision) {
-    Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10,precision));
     Number tempNumber = this * multiplier;
     tempNumber =
         (tempNumber >= Integer(0)) ? tempNumber.ceil() : tempNumber.floor();
@@ -198,21 +200,21 @@ class Decimal extends Number {
   }
 
   Number _roundUp(int precision) {
-    Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10,precision));
     return (this * multiplier).ceil() / multiplier;
   }
 
   Number _roundDown(int precision) {
-    Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10,precision));
     return (this * multiplier).floor() / multiplier;
   }
 
   Number _roundNearestEven(int precision){
-    Integer multiplier = Integer(pow(10,precision));
-    Number tempNumber = this * multiplier;
-    String integerPart = tempNumber.toInt().toString();
+    final Integer multiplier = Integer(pow(10,precision));
+    final Number tempNumber = this * multiplier;
+    final String integerPart = tempNumber.toInt().toString();
     var parts = tempNumber.toString().split('.'); 
-    String decimalPart = (parts.length == 2) ? parts[1] : "";
+    final String decimalPart = (parts.length == 2) ? parts[1] : "";
 
     if(decimalPart.length > 0 && decimalPart[0] == '5'){
       int lastDigit = int.tryParse(integerPart[integerPart.length-1]);
@@ -222,7 +224,7 @@ class Decimal extends Number {
   }
 
   Number _roundNearestFromZero(int precision){
-    Integer multiplier = Integer(pow(10,precision));
+    final Integer multiplier = Integer(pow(10,precision));
     return (this * multiplier).round() / multiplier;
   }
 }

--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:expression_language/src/number_type/integer.dart';
 import 'package:expression_language/src/number_type/number.dart';
 import 'package:rational/rational.dart';
@@ -137,7 +139,6 @@ class Decimal extends Number {
   @override
   int toInt() => toInteger().value;
 
-
   /// Return this [Decimal] as a [double].
   ///
   /// If the number is not representable as a [double], an approximation is
@@ -159,4 +160,69 @@ class Decimal extends Number {
 
   @override
   Integer truncate() => Decimal._fromRational(_rational.truncate()).toInteger();
+
+  Number preciseRound(int precision,
+      [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
+    if (precision >= 0) {
+      switch (mode) {
+        case RoundingMode.NEAREST_EVEN:
+          return _roundNearestEven(precision);
+        case RoundingMode.NEAREST_FROM_ZERO:
+          return _roundNearestFromZero(precision);
+        case RoundingMode.TOWARDS_ZERO:
+          return _roundTowardsZero(precision);
+        case RoundingMode.UP:
+          return _roundUp(precision);
+        case RoundingMode.DOWN:
+          return _roundDown(precision);
+      }
+      return null; //to suppress warning
+    }
+    else return toInteger().preciseRound(precision);
+  }
+
+  Number _roundTowardsZero(int precision) {
+    Integer multiplier = Integer(pow(10,precision));
+    Number tempNumber = this * multiplier;
+    tempNumber =
+        (tempNumber >= Integer(0)) ? tempNumber.floor() : tempNumber.ceil();
+    return tempNumber / multiplier;
+  }
+
+  Number _roundFromZero(int precision) {
+    Integer multiplier = Integer(pow(10,precision));
+    Number tempNumber = this * multiplier;
+    tempNumber =
+        (tempNumber >= Integer(0)) ? tempNumber.ceil() : tempNumber.floor();
+    return tempNumber / multiplier;
+  }
+
+  Number _roundUp(int precision) {
+    Integer multiplier = Integer(pow(10,precision));
+    return (this * multiplier).ceil() / multiplier;
+  }
+
+  Number _roundDown(int precision) {
+    Integer multiplier = Integer(pow(10,precision));
+    return (this * multiplier).floor() / multiplier;
+  }
+
+  Number _roundNearestEven(int precision){
+    Integer multiplier = Integer(pow(10,precision));
+    Number tempNumber = this * multiplier;
+    String integerPart = tempNumber.toInt().toString();
+    var parts = tempNumber.toString().split('.'); 
+    String decimalPart = (parts.length == 2) ? parts[1] : "";
+
+    if(decimalPart.length > 0 && decimalPart[0] == '5'){
+      int lastDigit = int.tryParse(integerPart[integerPart.length-1]);
+      return (lastDigit % 2 == 0) ? _roundTowardsZero(precision) : _roundFromZero(precision);
+    }
+    else return _roundNearestFromZero(precision);
+  }
+
+  Number _roundNearestFromZero(int precision){
+    Integer multiplier = Integer(pow(10,precision));
+    return (this * multiplier).round() / multiplier;
+  }
 }

--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -162,20 +162,20 @@ class Decimal extends Number {
   Integer truncate() => Decimal._fromRational(_rational.truncate()).toInteger();
 
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
+      [RoundingMode mode = RoundingMode.nearest_even]) {
     if (precision >= 0) {
       switch (mode) {
-        case RoundingMode.NEAREST_EVEN:
+        case RoundingMode.nearest_even:
           return _roundNearestEven(precision);
-        case RoundingMode.NEAREST_FROM_ZERO:
+        case RoundingMode.nearest_from_zero:
           return _roundNearestFromZero(precision);
-        case RoundingMode.TOWARDS_ZERO:
+        case RoundingMode.towards_zero:
           return _roundTowardsZero(precision);
-        case RoundingMode.FROM_ZERO:
+        case RoundingMode.from_zero:
           return _roundFromZero(precision);
-        case RoundingMode.UP:
+        case RoundingMode.up:
           return _roundUp(precision);
-        case RoundingMode.DOWN:
+        case RoundingMode.down:
           return _roundDown(precision);
       }
       return null; //to suppress warning

--- a/packages/expression_language/lib/src/number_type/integer.dart
+++ b/packages/expression_language/lib/src/number_type/integer.dart
@@ -123,7 +123,7 @@ class Integer extends Number {
 
   @override
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
+      [RoundingMode mode = RoundingMode.nearest_even]) {
     if (precision >= 0)
       return Integer(value);
     else {

--- a/packages/expression_language/lib/src/number_type/integer.dart
+++ b/packages/expression_language/lib/src/number_type/integer.dart
@@ -123,7 +123,7 @@ class Integer extends Number {
 
   @override
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.nearest_even]) {
+      [RoundingMode mode = RoundingMode.nearestEven]) {
     if (precision >= 0) {
       return Integer(value);
     } else {

--- a/packages/expression_language/lib/src/number_type/integer.dart
+++ b/packages/expression_language/lib/src/number_type/integer.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/number.dart';
 
@@ -120,13 +122,13 @@ class Integer extends Number {
   Integer truncate() => new Integer(value.truncate());
 
   @override
-  Number preciseRound(int precision,
+  Number roundWithPrecision(int precision,
       [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
     if (precision >= 0)
       return Integer(value);
     else {
-      int multiplier = 10^(-precision);
-      int adder = 5*(multiplier ~/ 10);
+      final int multiplier = pow(10,-precision);
+      final int adder = 5*(multiplier ~/ 10) * ((value < 0) ? -1 : 1);
       return Integer(((value + adder) ~/ multiplier) * multiplier);
     }
   }

--- a/packages/expression_language/lib/src/number_type/integer.dart
+++ b/packages/expression_language/lib/src/number_type/integer.dart
@@ -118,4 +118,16 @@ class Integer extends Number {
 
   @override
   Integer truncate() => new Integer(value.truncate());
+
+  @override
+  Number preciseRound(int precision,
+      [RoundingMode mode = RoundingMode.NEAREST_EVEN]) {
+    if (precision >= 0)
+      return Integer(value);
+    else {
+      int multiplier = 10^(-precision);
+      int adder = 5*(multiplier ~/ 10);
+      return Integer(((value + adder) ~/ multiplier) * multiplier);
+    }
+  }
 }

--- a/packages/expression_language/lib/src/number_type/integer.dart
+++ b/packages/expression_language/lib/src/number_type/integer.dart
@@ -124,11 +124,11 @@ class Integer extends Number {
   @override
   Number roundWithPrecision(int precision,
       [RoundingMode mode = RoundingMode.nearest_even]) {
-    if (precision >= 0)
+    if (precision >= 0) {
       return Integer(value);
-    else {
-      final int multiplier = pow(10,-precision);
-      final int adder = 5*(multiplier ~/ 10) * ((value < 0) ? -1 : 1);
+    } else {
+      final int multiplier = pow(10, -precision);
+      final int adder = 5 * (multiplier ~/ 10) * ((value < 0) ? -1 : 1);
       return Integer(((value + adder) ~/ multiplier) * multiplier);
     }
   }

--- a/packages/expression_language/lib/src/number_type/number.dart
+++ b/packages/expression_language/lib/src/number_type/number.dart
@@ -1,7 +1,7 @@
 import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/integer.dart';
 
-enum RoundingMode { NEAREST_EVEN,NEAREST_FROM_ZERO,TOWARDS_ZERO,FROM_ZERO,UP,DOWN }
+enum RoundingMode { nearest_even,nearest_from_zero,towards_zero,from_zero,up,down }
 
 abstract class Number implements Comparable<Number> {
   /**
@@ -151,7 +151,7 @@ abstract class Number implements Comparable<Number> {
    * Rounding modes are from IEEE 754 - https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules
    */
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.NEAREST_EVEN]);
+      [RoundingMode mode = RoundingMode.nearest_even]);
 
 
   /**

--- a/packages/expression_language/lib/src/number_type/number.dart
+++ b/packages/expression_language/lib/src/number_type/number.dart
@@ -1,6 +1,8 @@
 import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/integer.dart';
 
+enum RoundingMode { NEAREST_EVEN,NEAREST_FROM_ZERO,TOWARDS_ZERO,UP,DOWN }
+
 abstract class Number implements Comparable<Number> {
   /**
    * Test whether this value is numerically equal to `other`.
@@ -141,6 +143,16 @@ abstract class Number implements Comparable<Number> {
    *
    */
   Integer round();
+
+  /**Returns number rounded according to precision and rounding mode.
+   * If precision is negative, number is rounded to hundreds (-2), thousands (-3), etc.
+   * 
+   * If rounded number is integer, rounding mode NEAREST_EVEN is automatically used and cannot be changed.\
+   * Rounding modes are from IEEE 754 - https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules
+   */
+  Number preciseRound(int precision,
+      [RoundingMode mode = RoundingMode.NEAREST_EVEN]);
+
 
   /**
    * Returns the greatest integer no greater than `this`.

--- a/packages/expression_language/lib/src/number_type/number.dart
+++ b/packages/expression_language/lib/src/number_type/number.dart
@@ -1,7 +1,7 @@
 import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/integer.dart';
 
-enum RoundingMode { NEAREST_EVEN,NEAREST_FROM_ZERO,TOWARDS_ZERO,UP,DOWN }
+enum RoundingMode { NEAREST_EVEN,NEAREST_FROM_ZERO,TOWARDS_ZERO,FROM_ZERO,UP,DOWN }
 
 abstract class Number implements Comparable<Number> {
   /**
@@ -145,12 +145,12 @@ abstract class Number implements Comparable<Number> {
   Integer round();
 
   /**Returns number rounded according to precision and rounding mode.
-   * If precision is negative, number is rounded to hundreds (-2), thousands (-3), etc.
+   * If precision is negative, number is rounded to hundreds (-2), thousands (-3), etc. In that case, it rounds to nearest, ties away from zero.
    * 
    * If rounded number is integer, rounding mode NEAREST_EVEN is automatically used and cannot be changed.\
    * Rounding modes are from IEEE 754 - https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules
    */
-  Number preciseRound(int precision,
+  Number roundWithPrecision(int precision,
       [RoundingMode mode = RoundingMode.NEAREST_EVEN]);
 
 

--- a/packages/expression_language/lib/src/number_type/number.dart
+++ b/packages/expression_language/lib/src/number_type/number.dart
@@ -1,7 +1,7 @@
 import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/integer.dart';
 
-enum RoundingMode { nearest_even,nearest_from_zero,towards_zero,from_zero,up,down }
+enum RoundingMode { nearestEven,nearestFromZero,towardsZero,fromZero,up,down }
 
 abstract class Number implements Comparable<Number> {
   /**
@@ -151,7 +151,7 @@ abstract class Number implements Comparable<Number> {
    * Rounding modes are from IEEE 754 - https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules
    */
   Number roundWithPrecision(int precision,
-      [RoundingMode mode = RoundingMode.nearest_even]);
+      [RoundingMode mode = RoundingMode.nearestEven]);
 
 
   /**

--- a/packages/expression_language/lib/src/number_type/number.dart
+++ b/packages/expression_language/lib/src/number_type/number.dart
@@ -144,12 +144,12 @@ abstract class Number implements Comparable<Number> {
    */
   Integer round();
 
-  /**Returns number rounded according to precision and rounding mode.
-   * If precision is negative, number is rounded to hundreds (-2), thousands (-3), etc. In that case, it rounds to nearest, ties away from zero.
-   * 
-   * If rounded number is integer, rounding mode NEAREST_EVEN is automatically used and cannot be changed.\
-   * Rounding modes are from IEEE 754 - https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules
-   */
+  ///Returns number rounded according to [precision] and [RoundingMode].
+  /// 
+  /// If [precision] is negative, number is rounded to hundreds (-2), thousands (-3), etc. In that case, it rounds to nearest, ties away from zero.\
+  /// If rounded number is integer, rounding mode `nearestEven` is automatically used and cannot be changed.
+  /// 
+  /// Rounding modes are from IEEE 754 (https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules)
   Number roundWithPrecision(int precision,
       [RoundingMode mode = RoundingMode.nearestEven]);
 

--- a/packages/expression_language/lib/src/parser/expression_factory.dart
+++ b/packages/expression_language/lib/src/parser/expression_factory.dart
@@ -71,10 +71,17 @@ Expression createFunctionExpression(
     return ListCountFunctionExpression(parameters[0]);
   }
   if (functionName == "round") {
-    if (parameters.length == 3)
-      return RoundFunctionWithRoundingModeExpression(
-          parameters[0], parameters[1], parameters[2]);
-    else if (parameters.length == 2)
+    if (parameters.length == 3) {
+      if (parameters[2] is Expression<Integer>) {
+        return RoundFunctionIntRoundingModeExpression(
+            parameters[0], parameters[1], parameters[2]);
+      } else if (parameters[2] is Expression<String>) {
+        return RoundFunctionStringRoundingModeExpression(
+            parameters[0], parameters[1], parameters[2]);
+      }else{
+        throw InvalidParameter("Function $functionName expects integer or string as third parameter");
+      }
+    } else if (parameters.length == 2)
       return RoundFunctionExpression(parameters[0], parameters[1]);
     else
       throw InvalidParameterCount(

--- a/packages/expression_language/lib/src/parser/expression_factory.dart
+++ b/packages/expression_language/lib/src/parser/expression_factory.dart
@@ -63,5 +63,11 @@ Expression createFunctionExpression(
     }
     return ListCountFunctionExpression(parameters[0]);
   }
+  if (functionName == "round") {
+    if (parameters.length != 3) {
+      throw InvalidParameterCount("Function $functionName expect only 3 parameters");
+    }
+    return RoundFunctionExpression(parameters[0],parameters[1],parameters[2]);
+  }
   throw UnknownFunction("Unknown function name $functionName");
 }

--- a/packages/expression_language/lib/src/parser/expression_factory.dart
+++ b/packages/expression_language/lib/src/parser/expression_factory.dart
@@ -4,7 +4,8 @@ import 'package:expression_language/src/number_type/decimal.dart';
 import 'package:expression_language/src/number_type/integer.dart';
 import 'package:expression_language/src/parser/expression_parser_exceptions.dart';
 
-DelegateExpression createDelegateExpression(List<String> expressionPath, ExpressionProvider elementValue) {
+DelegateExpression createDelegateExpression(
+    List<String> expressionPath, ExpressionProvider elementValue) {
   if (elementValue is ExpressionProvider<Integer>) {
     return DelegateExpression<Integer>(expressionPath, elementValue);
   }
@@ -18,10 +19,12 @@ DelegateExpression createDelegateExpression(List<String> expressionPath, Express
     return DelegateExpression<Decimal>(expressionPath, elementValue);
   }
   if (elementValue is ExpressionProvider<ExpressionProviderElement>) {
-    return DelegateExpression<ExpressionProviderElement>(expressionPath, elementValue);
+    return DelegateExpression<ExpressionProviderElement>(
+        expressionPath, elementValue);
   }
   if (elementValue is ExpressionProvider<List<ExpressionProviderElement>>) {
-    return DelegateExpression<List<ExpressionProviderElement>>(expressionPath, elementValue);
+    return DelegateExpression<List<ExpressionProviderElement>>(
+        expressionPath, elementValue);
   }
   throw UnknownExpressionFactory("Unknown expression factory");
 }
@@ -40,34 +43,42 @@ ConditionalExpression createConditionalExpression(
   if (trueValue is Expression<Decimal>) {
     return ConditionalExpression<Decimal>(condition, trueValue, falseValue);
   }
-  throw UnknownExpressionTypeException("Unknown expression in conditional expression");
+  throw UnknownExpressionTypeException(
+      "Unknown expression in conditional expression");
 }
 
 Expression createFunctionExpression(
     String functionName, List<Expression> parameters) {
   if (functionName == "length") {
     if (parameters.length != 1) {
-      throw InvalidParameterCount("Function $functionName expect only 1 parameter");
+      throw InvalidParameterCount(
+          "Function $functionName expects only 1 parameter");
     }
     return LengthFunctionExpression(parameters[0]);
   }
   if (functionName == "toString") {
     if (parameters.length != 1) {
-      throw InvalidParameterCount("Function $functionName expect only 1 parameter");
+      throw InvalidParameterCount(
+          "Function $functionName expects only 1 parameter");
     }
     return ToStringFunctionExpression(parameters[0]);
   }
   if (functionName == "count") {
     if (parameters.length != 1) {
-      throw InvalidParameterCount("Function $functionName expect only 1 parameter");
+      throw InvalidParameterCount(
+          "Function $functionName expects only 1 parameter");
     }
     return ListCountFunctionExpression(parameters[0]);
   }
   if (functionName == "round") {
-    if (parameters.length != 3) {
-      throw InvalidParameterCount("Function $functionName expect only 3 parameters");
-    }
-    return RoundFunctionExpression(parameters[0],parameters[1],parameters[2]);
+    if (parameters.length == 3)
+      return RoundFunctionWithRoundingModeExpression(
+          parameters[0], parameters[1], parameters[2]);
+    else if (parameters.length == 2)
+      return RoundFunctionExpression(parameters[0], parameters[1]);
+    else
+      throw InvalidParameterCount(
+          "Function $functionName expects only 2 or 3 parameters");
   }
   throw UnknownFunction("Unknown function name $functionName");
 }

--- a/packages/expression_language/lib/src/parser/expression_parser_exceptions.dart
+++ b/packages/expression_language/lib/src/parser/expression_parser_exceptions.dart
@@ -32,6 +32,9 @@ class UnknownExpressionFactory extends ExpressionParserException {
   UnknownExpressionFactory(String message) : super(message);
 }
 
+class InvalidParameter extends ExpressionParserException {
+  InvalidParameter(String message) : super(message);
+}
 
 class InvalidParameterCount extends ExpressionParserException {
   InvalidParameterCount(String message) : super(message);

--- a/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
@@ -242,14 +242,25 @@ class CloneExpressionVisitor extends ExpressionVisitor {
   }
 
   @override
-  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression) {
+  void visitRoundFunctionIntRoundingMode(RoundFunctionIntRoundingModeExpression expression) {
     expression.value.accept(this);
     expression.precision.accept(this);
     expression.roundingMode.accept(this);
     var roundingMode = pop();
     var precision = pop();
     var value = pop();
-    push(RoundFunctionWithRoundingModeExpression(value,precision,roundingMode));
+    push(RoundFunctionIntRoundingModeExpression(value,precision,roundingMode));
+  }
+
+  @override
+  void visitRoundFunctionStringRoundingMode(RoundFunctionStringRoundingModeExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
+    expression.roundingMode.accept(this);
+    var roundingMode = pop();
+    var precision = pop();
+    var value = pop();
+    push(RoundFunctionStringRoundingModeExpression(value,precision,roundingMode));
   }
 
   @override

--- a/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
@@ -242,13 +242,22 @@ class CloneExpressionVisitor extends ExpressionVisitor {
   }
 
   @override
-  void visitRoundFunction(RoundFunctionExpression expression) {
+  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression) {
     expression.value.accept(this);
     expression.precision.accept(this);
     expression.roundingMode.accept(this);
     var roundingMode = pop();
     var precision = pop();
     var value = pop();
-    push(RoundFunctionExpression(value,precision,roundingMode));
+    push(RoundFunctionWithRoundingModeExpression(value,precision,roundingMode));
+  }
+
+  @override
+  void visitRoundFunction(RoundFunctionExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
+    var precision = pop();
+    var value = pop();
+    push(RoundFunctionExpression(value,precision));
   }
 }

--- a/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/clone_expression_visitor.dart
@@ -240,4 +240,15 @@ class CloneExpressionVisitor extends ExpressionVisitor {
     expression.value.accept(this);
     push(ListCountFunctionExpression(pop()));
   }
+
+  @override
+  void visitRoundFunction(RoundFunctionExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
+    expression.roundingMode.accept(this);
+    var roundingMode = pop();
+    var precision = pop();
+    var value = pop();
+    push(RoundFunctionExpression(value,precision,roundingMode));
+  }
 }

--- a/packages/expression_language/lib/src/visitors/expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/expression_visitor.dart
@@ -29,4 +29,5 @@ abstract class ExpressionVisitor {
   void visitLengthFunction(LengthFunctionExpression expression);
   void visitToStringFunction(ToStringFunctionExpression expression);
   void visitListCountFunction<T>(ListCountFunctionExpression<T> expression);
+  void visitRoundFunction(RoundFunctionExpression expression);
 }

--- a/packages/expression_language/lib/src/visitors/expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/expression_visitor.dart
@@ -29,6 +29,7 @@ abstract class ExpressionVisitor {
   void visitLengthFunction(LengthFunctionExpression expression);
   void visitToStringFunction(ToStringFunctionExpression expression);
   void visitListCountFunction<T>(ListCountFunctionExpression<T> expression);
-  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression);
+  void visitRoundFunctionIntRoundingMode(RoundFunctionIntRoundingModeExpression expression);
+  void visitRoundFunctionStringRoundingMode(RoundFunctionStringRoundingModeExpression expression);
   void visitRoundFunction(RoundFunctionExpression expression);
 }

--- a/packages/expression_language/lib/src/visitors/expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/expression_visitor.dart
@@ -29,5 +29,6 @@ abstract class ExpressionVisitor {
   void visitLengthFunction(LengthFunctionExpression expression);
   void visitToStringFunction(ToStringFunctionExpression expression);
   void visitListCountFunction<T>(ListCountFunctionExpression<T> expression);
+  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression);
   void visitRoundFunction(RoundFunctionExpression expression);
 }

--- a/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
@@ -147,9 +147,15 @@ abstract class TraversalExpressionsVisitor extends ExpressionVisitor {
   }
 
   @override
-  void visitRoundFunction(RoundFunctionExpression expression) {
+  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression) {
     expression.value.accept(this);
     expression.precision.accept(this);
     expression.roundingMode.accept(this);
+  }
+
+  @override
+  void visitRoundFunction(RoundFunctionExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
   }
 }

--- a/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
@@ -145,4 +145,11 @@ abstract class TraversalExpressionsVisitor extends ExpressionVisitor {
   void visitListCountFunction<T>(ListCountFunctionExpression<T> expression) {
     expression.value.accept(this);
   }
+
+  @override
+  void visitRoundFunction(RoundFunctionExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
+    expression.roundingMode.accept(this);
+  }
 }

--- a/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
+++ b/packages/expression_language/lib/src/visitors/traversal_expression_visitor.dart
@@ -1,4 +1,3 @@
-
 import 'package:expression_language/expression_language.dart';
 import '../expressions/expressions.dart';
 
@@ -35,7 +34,6 @@ abstract class TraversalExpressionsVisitor extends ExpressionVisitor {
     expression.left.accept(this);
     expression.right.accept(this);
   }
-
 
   @override
   void visitEqualString(EqualStringExpression expression) {
@@ -147,7 +145,16 @@ abstract class TraversalExpressionsVisitor extends ExpressionVisitor {
   }
 
   @override
-  void visitRoundFunctionWithRoundingMode(RoundFunctionWithRoundingModeExpression expression) {
+  void visitRoundFunctionIntRoundingMode(
+      RoundFunctionIntRoundingModeExpression expression) {
+    expression.value.accept(this);
+    expression.precision.accept(this);
+    expression.roundingMode.accept(this);
+  }
+
+  @override
+  void visitRoundFunctionStringRoundingMode(
+      RoundFunctionStringRoundingModeExpression expression) {
     expression.value.accept(this);
     expression.precision.accept(this);
     expression.roundingMode.accept(this);

--- a/packages/expression_language/test/features/expression_parser_can_solve.feature
+++ b/packages/expression_language/test/features/expression_parser_can_solve.feature
@@ -1,6 +1,30 @@
 Feature: Expression
   Tests an expression
 
+  Scenario: rounding test 1 - string rounding mode
+    When expression "round(13.5,0,"nearest_even")" is evaluated
+    Then decimal expression result is "14"
+
+  Scenario: rounding test 2 - string rounding mode
+    When expression "round(13.5,0,"nearest_from_zero")" is evaluated
+    Then decimal expression result is "14"
+
+  Scenario: rounding test 3 - string rounding mode
+    When expression "round(13.5,0,"towards_zero")" is evaluated
+    Then decimal expression result is "13"
+
+  Scenario: rounding test 4 - string rounding mode
+    When expression "round(13.5,0,"from_zero")" is evaluated
+    Then decimal expression result is "14"
+
+  Scenario: rounding test 5 - string rounding mode
+    When expression "round(13.5,0,"up")" is evaluated
+    Then decimal expression result is "14"
+
+  Scenario: rounding test 6 - string rounding mode
+    When expression "round(13.5,0,"down")" is evaluated
+    Then decimal expression result is "13"
+
   Scenario: rounding test - no rounding mode
     When expression "round(13.5,0)" is evaluated
     Then decimal expression result is "14"

--- a/packages/expression_language/test/features/expression_parser_can_solve.feature
+++ b/packages/expression_language/test/features/expression_parser_can_solve.feature
@@ -1,6 +1,214 @@
 Feature: Expression
   Tests an expression
 
+  Scenario: rounding test - no rounding mode
+    When expression "round(13.5,0)" is evaluated
+    Then decimal expression result is "14"
+
+  Scenario: rounding test - negative precision
+    When expression "round(13235.5,-2)" is evaluated
+    Then int expression result is "13200"
+
+  Scenario: rounding test - negative precision - tie
+    When expression "round(-13250.5,-2)" is evaluated
+    Then int expression result is "-13300"
+
+  Scenario: rounding test - negative precision - tie
+    When expression "round(13250.5,-2)" is evaluated
+    Then int expression result is "13300"
+
+  Scenario: rounding test 1 - rounding to nearest, ties to even
+    When expression "round(11.5,0,0)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 2 - rounding to nearest, ties to even
+    When expression "round(12.5,0,0)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 3 - rounding to nearest, ties to even
+    When expression "round(-11.5,0,0)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 4 - rounding to nearest, ties to even
+    When expression "round(-12.5,0,0)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 5 - rounding to nearest, ties to even - higher precision
+    When expression "round(-12.54855,4,0)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 6 - rounding to nearest, ties to even - higher precision
+    When expression "round(-12.54865,4,0)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 7 - rounding to nearest, ties to even - higher precision
+    When expression "round(12.54855,4,0)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 8 - rounding to nearest, ties to even - higher precision
+    When expression "round(12.54855,4,0)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 1 - rounding to nearest, ties away from zero
+    When expression "round(11.5,0,1)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 2 - rounding to nearest, ties away from zero
+    When expression "round(12.5,0,1)" is evaluated
+    Then decimal expression result is "13"
+
+  Scenario: rounding test 3 - rounding to nearest, ties away from zero
+    When expression "round(-11.5,0,1)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 4 - rounding to nearest, ties away from zero
+    When expression "round(-12.5,0,1)" is evaluated
+    Then decimal expression result is "-13"
+
+  Scenario: rounding test 5 - rounding to nearest, ties away from zero - higher precision
+    When expression "round(-12.54855,4,1)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 6 - rounding to nearest, ties away from zero - higher precision
+    When expression "round(-12.54865,4,1)" is evaluated
+    Then decimal expression result is "-12.5487"
+
+  Scenario: rounding test 7 - rounding to nearest, ties away from zero - higher precision
+    When expression "round(12.54855,4,1)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 8 - rounding to nearest, ties away from zero - higher precision
+    When expression "round(12.54855,4,1)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 1 - rounding towards zero
+    When expression "round(11.5,0,2)" is evaluated
+    Then decimal expression result is "11"
+
+  Scenario: rounding test 2 - rounding towards zero
+    When expression "round(12.5,0,2)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 3 - rounding towards zero
+    When expression "round(-11.5,0,2)" is evaluated
+    Then decimal expression result is "-11"
+
+  Scenario: rounding test 4 - rounding towards zero
+    When expression "round(-12.5,0,2)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 5 - rounding towards zero - higher precision
+    When expression "round(-12.54855,4,2)" is evaluated
+    Then decimal expression result is "-12.5485"
+
+  Scenario: rounding test 6 - rounding towards zero - higher precision
+    When expression "round(-12.54865,4,2)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 7 - rounding towards zero - higher precision
+    When expression "round(12.54855,4,2)" is evaluated
+    Then decimal expression result is "12.5485"
+
+  Scenario: rounding test 8 - rounding towards zero - higher precision
+    When expression "round(12.54855,4,2)" is evaluated
+    Then decimal expression result is "12.5485"
+
+  Scenario: rounding test 1 - rounding from zero
+    When expression "round(11.5,0,3)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 2 - rounding from zero
+    When expression "round(12.5,0,3)" is evaluated
+    Then decimal expression result is "13"
+
+  Scenario: rounding test 3 - rounding from zero
+    When expression "round(-11.5,0,3)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 4 - rounding from zero
+    When expression "round(-12.5,0,3)" is evaluated
+    Then decimal expression result is "-13"
+
+  Scenario: rounding test 5 - rounding from zero - higher precision
+    When expression "round(-12.54855,4,3)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 6 - rounding from zero - higher precision
+    When expression "round(-12.54865,4,3)" is evaluated
+    Then decimal expression result is "-12.5487"
+
+  Scenario: rounding test 7 - rounding from zero - higher precision
+    When expression "round(12.54855,4,3)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 8 - rounding from zero - higher precision
+    When expression "round(12.54855,4,3)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 1 - rounding up
+    When expression "round(11.5,0,4)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 2 - rounding up
+    When expression "round(12.5,0,4)" is evaluated
+    Then decimal expression result is "13"
+
+  Scenario: rounding test 3 - rounding up
+    When expression "round(-11.5,0,4)" is evaluated
+    Then decimal expression result is "-11"
+
+  Scenario: rounding test 4 - rounding up
+    When expression "round(-12.5,0,4)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 5 - rounding up - higher precision
+    When expression "round(-12.54855,4,4)" is evaluated
+    Then decimal expression result is "-12.5485"
+
+  Scenario: rounding test 6 - rounding up - higher precision
+    When expression "round(-12.54865,4,4)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 7 - rounding up - higher precision
+    When expression "round(12.54855,4,4)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 8 - rounding up - higher precision
+    When expression "round(12.54855,4,4)" is evaluated
+    Then decimal expression result is "12.5486"
+
+  Scenario: rounding test 1 - rounding down
+    When expression "round(11.5,0,5)" is evaluated
+    Then decimal expression result is "11"
+
+  Scenario: rounding test 2 - rounding down
+    When expression "round(12.5,0,5)" is evaluated
+    Then decimal expression result is "12"
+
+  Scenario: rounding test 3 - rounding down
+    When expression "round(-11.5,0,5)" is evaluated
+    Then decimal expression result is "-12"
+
+  Scenario: rounding test 4 - rounding down
+    When expression "round(-12.5,0,5)" is evaluated
+    Then decimal expression result is "-13"
+
+  Scenario: rounding test 5 - rounding down - higher precision
+    When expression "round(-12.54855,4,5)" is evaluated
+    Then decimal expression result is "-12.5486"
+
+  Scenario: rounding test 6 - rounding down - higher precision
+    When expression "round(-12.54865,4,5)" is evaluated
+    Then decimal expression result is "-12.5487"
+
+  Scenario: rounding test 7 - rounding down - higher precision
+    When expression "round(12.54855,4,5)" is evaluated
+    Then decimal expression result is "12.5485"
+
+  Scenario: rounding test 8 - rounding down - higher precision
+    When expression "round(12.54855,4,5)" is evaluated
+    Then decimal expression result is "12.5485"
+
   Scenario: it should solve an mixed expression
     When expression "5.00000000000001 > 5 && 4.00 <= 4" is evaluated
     Then bool expression result is "true"
@@ -88,7 +296,7 @@ Feature: Expression
   Scenario: it should compute 2.5 when given 5.0/2
     When expression "5.0/2" is evaluated
     Then decimal expression result is "2.5"
-  
+
   Scenario: it should compute 3 when given 7/2
     When expression "7/2" is evaluated
     Then int expression result is "3"

--- a/packages/expression_language/test/features/expression_parser_can_solve.feature
+++ b/packages/expression_language/test/features/expression_parser_can_solve.feature
@@ -2,19 +2,19 @@ Feature: Expression
   Tests an expression
 
   Scenario: rounding test 1 - string rounding mode
-    When expression "round(13.5,0,"nearest_even")" is evaluated
+    When expression "round(13.5,0,"nearestEven")" is evaluated
     Then decimal expression result is "14"
 
   Scenario: rounding test 2 - string rounding mode
-    When expression "round(13.5,0,"nearest_from_zero")" is evaluated
+    When expression "round(13.5,0,"nearestFromZero")" is evaluated
     Then decimal expression result is "14"
 
   Scenario: rounding test 3 - string rounding mode
-    When expression "round(13.5,0,"towards_zero")" is evaluated
+    When expression "round(13.5,0,"towardsZero")" is evaluated
     Then decimal expression result is "13"
 
   Scenario: rounding test 4 - string rounding mode
-    When expression "round(13.5,0,"from_zero")" is evaluated
+    When expression "round(13.5,0,"fromZero")" is evaluated
     Then decimal expression result is "14"
 
   Scenario: rounding test 5 - string rounding mode


### PR DESCRIPTION
Added function `round(Number,precision,RoundingMode),` which returns `Number` rounded according to 
`precision` and `RoundingMode`. Rounding modes are from IEEE 754, it can be omitted, in that case, nearest-even mode is used. Parameter `RoundingMode` can be integer in range from 0 to 4 or string. \
If precision is negative, number is rounded to hundreds (-2), thousands (-3) etc.