### PR TITLE
Ok/container element

### DIFF
--- a/packages/dynamic_forms/lib/src/form_elements/check_box.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/check_box.dart
@@ -9,7 +9,7 @@ class CheckBox extends FormElement {
 
   void fillCheckBox({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<bool> value,
     @required ElementValue<String> label,

--- a/packages/dynamic_forms/lib/src/form_elements/container.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/container.dart
@@ -1,0 +1,29 @@
+
+import 'package:dynamic_forms/dynamic_forms.dart';
+import 'package:expression_language/expression_language.dart';
+import 'package:meta/meta.dart';
+
+class Container extends FormElement {
+  ElementValue<List<FormElement>> children;
+
+  void fillContainer(
+      {@required String id,
+      @required ElementValue<FormElement> parent,
+      @required ElementValue<bool> isVisible,
+      @required ElementValue<List<FormElement>> children}) {
+    fillFormElement(id: id, parent: parent, isVisible: isVisible);
+    this.children = registerElementValue("children", children);
+  }
+
+  @override
+  ExpressionProviderElement clone(ExpressionProvider<ExpressionProviderElement> parent) {
+    var result = Container();
+    result.fillContainer(
+      id: this.id,
+      parent: parent,
+      isVisible: this.isVisible.clone(),
+      children: cloneChildren(children, result),
+    );
+    return result;
+  }
+}

--- a/packages/dynamic_forms/lib/src/form_elements/dropdown_button.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/dropdown_button.dart
@@ -10,7 +10,7 @@ class DropdownButton extends FormElement {
 
   void fillDropdownButton({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<List<DropdownOption>> options,
     @required ElementValue<String> value,

--- a/packages/dynamic_forms/lib/src/form_elements/dropdown_option.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/dropdown_option.dart
@@ -9,7 +9,7 @@ class DropdownOption extends FormElement {
 
   void fillDropdownOption({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<String> label,
     @required ElementValue<String> value,

--- a/packages/dynamic_forms/lib/src/form_elements/form.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/form.dart
@@ -7,7 +7,7 @@ class Form extends FormGroup {
   void fillForm(
       {@required String id,
       @required ElementValue<bool> isVisible,
-      @required ElementValue<List<ExpressionProviderElement>> children,
+      @required ElementValue<List<FormElement>> children,
       @required ElementValue<String> name}) {
     fillFormGroup(
         id: id,

--- a/packages/dynamic_forms/lib/src/form_elements/form_element.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/form_element.dart
@@ -9,7 +9,7 @@ abstract class FormElement implements ExpressionProviderElement {
   static const String DEFAULT_PROPERTY_NAME = "value";
 
   String id;
-  ElementValue<ExpressionProviderElement> parent;
+  ElementValue<FormElement> parent;
   Map<String, ElementValue> _properties = {};
   ElementValue<bool> isVisible;
 
@@ -17,7 +17,7 @@ abstract class FormElement implements ExpressionProviderElement {
 
   void fillFormElement(
       {@required String id,
-      @required ElementValue<ExpressionProviderElement> parent,
+      @required ElementValue<FormElement> parent,
       @required ElementValue<bool> isVisible}) {
     this.id = id;
     this.isVisible = registerElementValue("isVisible", isVisible);
@@ -49,7 +49,7 @@ abstract class FormElement implements ExpressionProviderElement {
 
   Map<String, ElementValue> getProperties() => _properties;
 
-  ElementValue<List<T>> cloneChildren<T extends ExpressionProviderElement>(
+  ElementValue<List<T>> cloneChildren<T extends FormElement>(
       ElementValue<List<T>> children, ExpressionProviderElement parent) {
     var childrenElements = children.value;
     var childrenCopy = List<T>.from(

--- a/packages/dynamic_forms/lib/src/form_elements/form_elements.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/form_elements.dart
@@ -3,6 +3,7 @@ export 'dropdown_button.dart';
 export 'dropdown_option.dart';
 export 'form.dart';
 export 'form_group.dart';
+export 'container.dart';
 export 'form_element.dart';
 export 'label.dart';
 export 'radio_button.dart';

--- a/packages/dynamic_forms/lib/src/form_elements/form_group.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/form_group.dart
@@ -1,25 +1,25 @@
 import 'package:dynamic_forms/dynamic_forms.dart';
-import 'package:dynamic_forms/src/form_elements/form_element.dart';
+import 'package:dynamic_forms/src/form_elements/container.dart';
 import 'package:expression_language/expression_language.dart';
 import 'package:meta/meta.dart';
 
-class FormGroup extends FormElement {
-  ElementValue<List<ExpressionProviderElement>> children;
+class FormGroup extends Container {
   ElementValue<String> name;
 
   void fillFormGroup(
       {@required String id,
-      @required ElementValue<ExpressionProviderElement> parent,
+      @required ElementValue<FormElement> parent,
       @required ElementValue<bool> isVisible,
-      @required ElementValue<List<ExpressionProviderElement>> children,
+      @required ElementValue<List<FormElement>> children,
       @required ElementValue<String> name}) {
-    fillFormElement(id: id, parent: parent, isVisible: isVisible);
-    this.children = registerElementValue("children", children);
+    fillContainer(
+        id: id, parent: parent, isVisible: isVisible, children: children);
     this.name = registerElementValue("name", name);
   }
 
   @override
-  ExpressionProviderElement clone(ExpressionProvider<ExpressionProviderElement> parent) {
+  ExpressionProviderElement clone(
+      ExpressionProvider<ExpressionProviderElement> parent) {
     var result = FormGroup();
     result.fillFormGroup(
       id: this.id,

--- a/packages/dynamic_forms/lib/src/form_elements/label.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/label.dart
@@ -8,7 +8,7 @@ class Label extends FormElement {
 
   void fillLabel(
       {@required String id,
-      @required ElementValue<ExpressionProviderElement> parent,
+      @required ElementValue<FormElement> parent,
       @required ElementValue<bool> isVisible,
       @required ElementValue<String> value}) {
     super.fillFormElement(id: id, parent: parent, isVisible: isVisible);

--- a/packages/dynamic_forms/lib/src/form_elements/radio_button.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/radio_button.dart
@@ -9,7 +9,7 @@ class RadioButton extends FormElement {
 
   void fillRadioButton({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<String> label,
     @required ElementValue<String> value,

--- a/packages/dynamic_forms/lib/src/form_elements/radio_button_group.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/radio_button_group.dart
@@ -6,17 +6,17 @@ import 'package:meta/meta.dart';
 
 class RadioButtonGroup extends FormElement {
   ElementValue<String> value;
-  ElementValue<List<RadioButton>> children;
+  ElementValue<List<RadioButton>> radioButtons;
 
   void fillRadioButtonGroup({
     @required String id,
     @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
-    @required ElementValue<List<RadioButton>> children,
+    @required ElementValue<List<RadioButton>> radioButtons,
     @required ElementValue<String> value,
   }) {
     fillFormElement(id: id, parent: parent, isVisible: isVisible);
-    this.children = registerElementValue("children", children);
+    this.radioButtons = registerElementValue("radioButtons", radioButtons);
     this.value = registerElementValue("value", value);
   }
 
@@ -28,7 +28,7 @@ class RadioButtonGroup extends FormElement {
       id: this.id,
       parent: parent,
       isVisible: this.isVisible.clone(),
-      children: cloneChildren(this.children, result),
+      radioButtons: cloneChildren(this.radioButtons, result),
       value: this.value.clone(),
     );
     return result;

--- a/packages/dynamic_forms/lib/src/form_elements/radio_button_group.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/radio_button_group.dart
@@ -10,7 +10,7 @@ class RadioButtonGroup extends FormElement {
 
   void fillRadioButtonGroup({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<List<RadioButton>> children,
     @required ElementValue<String> value,

--- a/packages/dynamic_forms/lib/src/form_elements/required_validation.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/required_validation.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 class RequiredValidation extends Validation {
   void fillRequiredValidation({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<String> message,
   }) {

--- a/packages/dynamic_forms/lib/src/form_elements/text.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/text.dart
@@ -12,7 +12,7 @@ class Text extends FormElement {
 
   void fillText({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<String> value,
     @required ElementValue<String> label,

--- a/packages/dynamic_forms/lib/src/form_elements/validation.dart
+++ b/packages/dynamic_forms/lib/src/form_elements/validation.dart
@@ -9,7 +9,7 @@ class Validation extends FormElement {
 
   void fillValidation({
     @required String id,
-    @required ElementValue<ExpressionProviderElement> parent,
+    @required ElementValue<FormElement> parent,
     @required ElementValue<bool> isVisible,
     @required ElementValue<bool> isValid,
     @required ElementValue<String> message,

--- a/packages/dynamic_forms/lib/src/iterators/form_element_iterator.dart
+++ b/packages/dynamic_forms/lib/src/iterators/form_element_iterator.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 
 import 'package:dynamic_forms/dynamic_forms.dart';
-import 'package:expression_language/expression_language.dart';
 
 Iterable<TFormElement> getFormElementIterator<TFormElement extends FormElement>(
     FormElement formElement) sync* {
@@ -16,15 +15,15 @@ Iterable<TFormElement> getFormElementIterator<TFormElement extends FormElement>(
     var formElements = formElement
         .getProperties()
         .values
-        .whereType<ElementValue<ExpressionProviderElement>>()
-        .map((v) => v.value as FormElement)
+        .whereType<ElementValue<FormElement>>()
+        .map((v) => v.value)
         .toList();
 
     var formListElements = formElement
         .getProperties()
         .values
-        .whereType<ElementValue<List<ExpressionProviderElement>>>()
-        .map((v) => v.value.cast<FormElement>())
+        .whereType<ElementValue<List<FormElement>>>()
+        .map((v) => v.value)
         .expand((x) => x);
     formElements.addAll(formListElements);
 

--- a/packages/dynamic_forms/lib/src/parser/form_element_parsers/dropdown_button_parser.dart
+++ b/packages/dynamic_forms/lib/src/parser/form_element_parsers/dropdown_button_parser.dart
@@ -16,7 +16,7 @@ class DropdownButtonParser extends FormElementParser<DropdownButton> {
       isVisible: getIsVisible(element),
       parent: getParentValue(parent),
       value: getStringValue(element, "value", isImmutable: false),
-      options: getChildrenElement(element, dropdownButton, "options", parser),
+      options: getChildren<DropdownOption>(element, dropdownButton, parser),
     );
     return dropdownButton;
   }

--- a/packages/dynamic_forms/lib/src/parser/form_element_parsers/form_group_parser.dart
+++ b/packages/dynamic_forms/lib/src/parser/form_element_parsers/form_group_parser.dart
@@ -16,7 +16,7 @@ class FormGroupParser extends FormElementParser<FormGroup> {
       isVisible: getIsVisible(element),
       parent: getParentValue(parent),
       name: getStringValue(element, "name"),
-      children: getChildren(element, formGroup, parser),
+      children: getChildren<FormElement>(element, formGroup, parser),
     );
     return formGroup;
   }

--- a/packages/dynamic_forms/lib/src/parser/form_element_parsers/form_parser.dart
+++ b/packages/dynamic_forms/lib/src/parser/form_element_parsers/form_parser.dart
@@ -16,7 +16,7 @@ class FormParser extends FormElementParser<Form> {
       id: getAttribute(element, "id"),
       isVisible: getIsVisible(element),
       name: getStringValue(element, "name"),
-      children: getChildren(element, form, parser),
+      children: getChildren<FormElement>(element, form, parser),
     );
     return form;
   }

--- a/packages/dynamic_forms/lib/src/parser/form_element_parsers/radio_button_group_parser.dart
+++ b/packages/dynamic_forms/lib/src/parser/form_element_parsers/radio_button_group_parser.dart
@@ -16,10 +16,7 @@ class RadioButtonGroupParser extends FormElementParser<RadioButtonGroup> {
       isVisible: getIsVisible(element),
       parent: getParentValue(parent),
       value: getStringValue(element, "value", isImmutable: false),
-      children: PrimitiveMutableElementValue(element.children
-          .where((c) => c is XmlElement)
-          .map((c) => parser(c, radioButtonGroup) as RadioButton)
-          .toList()),
+      radioButtons: getChildren<RadioButton>(element, radioButtonGroup, parser),
     );
     return radioButtonGroup;
   }

--- a/packages/dynamic_forms/lib/src/parser/form_element_parsers/text_parser.dart
+++ b/packages/dynamic_forms/lib/src/parser/form_element_parsers/text_parser.dart
@@ -18,7 +18,7 @@ class TextParser extends FormElementParser<Text> {
         value: getStringValue(element, "value", isImmutable: false),
         label: getStringValue(element, "label"),
         textInputType: getStringValue(element, "textInputType"),
-        validations: getChildrenElement(element, text, "validations", parser));
+        validations: getChildrenFromElement<Validation>(element, text, "validations", parser));
     return text;
   }
 }

--- a/packages/dynamic_forms/lib/src/parser/parsing_helpers.dart
+++ b/packages/dynamic_forms/lib/src/parser/parsing_helpers.dart
@@ -56,18 +56,19 @@ ElementValue<T> _createPrimitiveElementValue<T>(T value, bool isImmutable) {
       : PrimitiveMutableElementValue<T>(value);
 }
 
-ElementValue<List<FormElement>> getChildren(XmlElement element,
+ElementValue<List<TFormElement>> getChildren<TFormElement extends FormElement>(XmlElement element,
         FormElement parent, FormElementParserFunction parser, {bool isImmutable = true}) =>
     _createPrimitiveElementValue(element.children
-        .where((c) => c is XmlElement)
+        .where((c) => c is XmlElement && !c.name.qualified.startsWith(element.name.qualified + "."))
         .map((c) => parser(c, parent))
+        .cast<TFormElement>()
         .toList(), isImmutable);
 
 ElementValue<FormElement> getParentValue(FormElement parent) {
   return PrimitiveImmutableElementValue(parent);
 }
 
-ElementValue<List<T>> getChildrenElement<T>(
+ElementValue<List<TFormElement>> getChildrenFromElement<TFormElement>(
     XmlElement element,
     FormElement parent,
     String childrenElementName,
@@ -75,10 +76,11 @@ ElementValue<List<T>> getChildrenElement<T>(
     {bool isImmutable = true}) {
   var childrenXmlElement = getPropertyAsElement(element, childrenElementName);
   var children = childrenXmlElement == null
-      ? List<T>()
+      ? List<TFormElement>()
       : childrenXmlElement.children
           .where((c) => c is XmlElement)
-          .map((c) => parser(c, parent) as T)
+          .map((c) => parser(c, parent))
+          .cast<TFormElement>()
           .toList();
   var validations = _createPrimitiveElementValue(children, isImmutable);
   return validations;

--- a/packages/dynamic_forms/lib/src/parser/parsing_helpers.dart
+++ b/packages/dynamic_forms/lib/src/parser/parsing_helpers.dart
@@ -1,5 +1,4 @@
 import 'package:dynamic_forms/dynamic_forms.dart';
-import 'package:expression_language/expression_language.dart';
 import 'package:xml/xml.dart';
 
 typedef FormElementParserFunction = FormElement Function(
@@ -57,14 +56,14 @@ ElementValue<T> _createPrimitiveElementValue<T>(T value, bool isImmutable) {
       : PrimitiveMutableElementValue<T>(value);
 }
 
-ElementValue<List<ExpressionProviderElement>> getChildren(XmlElement element,
+ElementValue<List<FormElement>> getChildren(XmlElement element,
         FormElement parent, FormElementParserFunction parser, {bool isImmutable = true}) =>
     _createPrimitiveElementValue(element.children
         .where((c) => c is XmlElement)
         .map((c) => parser(c, parent))
         .toList(), isImmutable);
 
-ElementValue<ExpressionProviderElement> getParentValue(FormElement parent) {
+ElementValue<FormElement> getParentValue(FormElement parent) {
   return PrimitiveImmutableElementValue(parent);
 }
 

--- a/packages/flutter_dynamic_forms/example/assets/test_form1.xml
+++ b/packages/flutter_dynamic_forms/example/assets/test_form1.xml
@@ -76,7 +76,6 @@
         </formGroup>
         <formGroup id="formgroup3" name="Form section 3">
             <dropdownButton id="dropdownButton1" value="CD">
-            <dropdownButton.options>
                 <dropdownOption value="AF" label="Afghanistan"/>
                 <dropdownOption value="AR" label="Argentina"/>
                 <dropdownOption value="BY" label="Belarus"/>
@@ -85,7 +84,6 @@
                 <dropdownOption value="FK" label="Falkland Islands"/>
                 <dropdownOption value="GE" label="Georgia"/>
                 <dropdownOption value="GN" label="Guinea" />
-                </dropdownButton.options>
             </dropdownButton>
         </formGroup>
     </formGroup>

--- a/packages/flutter_dynamic_forms/example/lib/dynamic_form/dynamic_form_screen.dart
+++ b/packages/flutter_dynamic_forms/example/lib/dynamic_form/dynamic_form_screen.dart
@@ -50,7 +50,7 @@ class DynamicFormScreen extends StatelessWidget {
         builder: (context) {
           return AlertDialog(
             title: flutter.Text('Form data'),
-            content: Container(
+            content: flutter.Container(
               width: double.maxFinite,
               height: 300.0,
               child: ListView(

--- a/packages/flutter_dynamic_forms/example/lib/reactive_renderers/reactive_radio_button_group_renderer.dart
+++ b/packages/flutter_dynamic_forms/example/lib/reactive_renderers/reactive_radio_button_group_renderer.dart
@@ -12,8 +12,8 @@ class ReactiveRadioButtonGroupRenderer
       FormElementEventDispatcherFunction dispatcher,
       FormElementRendererFunction renderer) {
     return StreamBuilder<List<model.RadioButton>>(
-      initialData: element.children.value,
-      stream: element.children.valueChanged,
+      initialData: element.radioButtons.value,
+      stream: element.radioButtons.valueChanged,
       builder: (context, snapshot) {
         return StreamBuilder(
           stream: Observable.merge(

--- a/packages/flutter_dynamic_forms/example/lib/renderers/radio_button_group_renderer.dart
+++ b/packages/flutter_dynamic_forms/example/lib/renderers/radio_button_group_renderer.dart
@@ -15,7 +15,7 @@ class RadioButtonGroupRenderer
         padding: const EdgeInsets.all(8.0),
       )
     ];
-    for (var child in element.children.value) {
+    for (var child in element.radioButtons.value) {
       if (child.isVisible.value) {
         childrenWidgets.add(renderer(child, context));
       }


### PR DESCRIPTION
Add container element.
Using FormElement instead of ExpressionProviderElement in all places where we do not need this abstraction.
Unify API of Radio buttons and Dropdown buttons