### PR TITLE
expression_language package mods for updated rational and other deps

### DIFF
--- a/packages/expression_language/lib/src/number_type/decimal.dart
+++ b/packages/expression_language/lib/src/number_type/decimal.dart
@@ -1,8 +1,9 @@
 import 'dart:math';
+import 'package:rational/rational.dart';
+import 'package:decimal/decimal.dart' as RationalDecimal;
 
 import 'package:expression_language/src/number_type/integer.dart';
 import 'package:expression_language/src/number_type/number.dart';
-import 'package:rational/rational.dart';
 
 class Decimal extends Number {
   Rational _rational;
@@ -54,7 +55,7 @@ class Decimal extends Number {
   }
 
   @override
-  String toString() => _rational.toDecimalString();
+  String toString() => _rational.toDecimal(scaleOnInfinitePrecision: 10).toString();
 
   @override
   int compareTo(Number other) {
@@ -86,7 +87,7 @@ class Decimal extends Number {
 
   @override
   Integer operator ~/(Number other) =>
-      Decimal._fromRational(_rational ~/ _convertToDecimal(other)._rational)
+      Decimal._fromRational(Rational(_rational ~/ _convertToDecimal(other)._rational))
           .toInteger();
 
   @override
@@ -106,13 +107,13 @@ class Decimal extends Number {
       _rational >= _convertToDecimal(other)._rational;
 
   @override
-  bool get isNaN => _rational.isNaN;
+  bool get isNaN => false;
 
   @override
-  bool get isInfinite => _rational.isInfinite;
+  bool get isInfinite => false;
 
   @override
-  bool get isNegative => _rational.isNegative;
+  bool get isNegative => ((_rational.numerator.isNegative || _rational.denominator.isNegative) && (!_rational.numerator.isNegative || !_rational.denominator.isNegative));
 
   @override
   Number abs() => Decimal._fromRational(_rational.abs());
@@ -121,20 +122,20 @@ class Decimal extends Number {
   Integer get sign => Integer(_rational.signum);
 
   @override
-  Integer ceil() => Decimal._fromRational(_rational.ceil()).toInteger();
+  Integer ceil() => Decimal._fromRational(Rational(_rational.ceil())).toInteger();
 
   @override
-  Integer floor() => Decimal._fromRational(_rational.floor()).toInteger();
+  Integer floor() => Decimal._fromRational(Rational(_rational.floor())).toInteger();
 
   @override
   Number remainder(Number other) => Decimal._fromRational(
       _rational.remainder(Rational.parse(other.toString())));
 
   @override
-  Integer round() => Decimal._fromRational(_rational.round()).toInteger();
+  Integer round() => Decimal._fromRational(Rational(_rational.round())).toInteger();
 
   @override
-  Integer toInteger() => Integer(_rational.toInt());
+  Integer toInteger() => Integer(_rational.toBigInt().toInt());
 
   @override
   int toInt() => toInteger().value;
@@ -148,18 +149,18 @@ class Decimal extends Number {
 
   @override
   String toStringAsExponential([int? fractionDigits]) =>
-      _rational.toStringAsExponential(fractionDigits);
+      _rational.toDecimal().toStringAsExponential(fractionDigits ?? 0);
 
   @override
   String toStringAsFixed(int fractionDigits) =>
-      _rational.toStringAsFixed(fractionDigits);
+      _rational.toDecimal().toStringAsFixed(fractionDigits);
 
   @override
   String toStringAsPrecision(int precision) =>
-      _rational.toStringAsPrecision(precision);
+      _rational.toDecimal().toStringAsPrecision(precision);
 
   @override
-  Integer truncate() => Decimal._fromRational(_rational.truncate()).toInteger();
+  Integer truncate() => Decimal._fromRational(Rational(_rational.truncate())).toInteger();
 
   @override
   Number roundWithPrecision(int precision,

--- a/packages/expression_language/pubspec.yaml
+++ b/packages/expression_language/pubspec.yaml
@@ -7,11 +7,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  petitparser: ^4.0.0
-  rational: ^1.0.0
+  petitparser: ^5.1.0
+  rational: ^2.2.2
+  decimal: ^2.3.2
 
 dev_dependencies:
-  test: ^1.16.0
-  gherkin: ^1.1.5+1
-  glob: ^1.2.0
-  pedantic: ^1.11.0
+  test: ^1.22.2
+  gherkin: ^3.1.0
+  glob: ^2.1.0
+  lints: ^1.0.1

--- a/packages/expression_language/test/expressions_test.dart
+++ b/packages/expression_language/test/expressions_test.dart
@@ -1,4 +1,6 @@
-// @dart=2.9
+/* 
+	// @dart=2.9
+*/
 
 import 'dart:async';
 import 'package:gherkin/gherkin.dart';
@@ -7,19 +9,18 @@ import 'package:glob/glob.dart';
 import 'supporting_files/index.dart';
 
 void main() async {
-  final config = TestConfiguration()
-    ..features = [Glob(r'test/features/**.feature')]
-    ..exitAfterTestRun = false
-    ..reporters = [
+  final config = TestConfiguration(
+    features : [Glob(r'test/features/**.feature')],
+    reporters : [
       StdoutReporter(MessageLevel.error),
       ProgressReporter(),
       TestRunSummaryReporter(),
       JsonReporter(path: 'test/report.json')
-    ]
-    ..createWorld = (TestConfiguration config) {
+    ],
+    createWorld : (TestConfiguration config) {
       return Future.value(ExpressionWorld());
-    }
-    ..stepDefinitions = [
+    },
+    stepDefinitions : [
       GivenFormElementIsProvided(),
       GivenCustomExpressionIsProvided(),
       WhenExpressionIsEvaluated(),
@@ -29,7 +30,8 @@ void main() async {
       ThenBoolExpressionResult(),
       ThenExceptionThrownResult(),
       ThenDateTimeExpressionResult(),
-    ];
+    ]
+  );
 
   var runner = GherkinRunner();
   await runner.execute(config);

--- a/packages/expression_language/test/features/expression_can_solve.feature
+++ b/packages/expression_language/test/features/expression_can_solve.feature
@@ -649,7 +649,7 @@ Feature: Expression
 
   Scenario: Negate Nullable bool
     Given form element is provided
-    When expression "!@testElement.nullableBoolValue!" is evaluated
+    When expression "!(@testElement.nullableBoolValue!)" is evaluated
     Then bool expression result is "false"
 
   Scenario: Nullable Decimal

--- a/packages/expression_language/test/features/passed_in_old_version.feature
+++ b/packages/expression_language/test/features/passed_in_old_version.feature
@@ -1,0 +1,7 @@
+Feature: Expression
+  Tests an expression
+
+  Scenario: Negate Nullable bool
+    Given form element is provided
+    When expression "!@testElement.nullableBoolValue!" is evaluated
+    Then bool expression result is "false"


### PR DESCRIPTION
This pull primarily modifies the expression_language package to work with the current versions of the dependencies.
It primarily modifies `decimal.dart` to work with current rational package.
It does add a new `passed_in_old_version.feature` file which contains one of the previous tests which no longer passes.  I believe this must be because of a change within the petite_parser package.   I was able to modify this test within the existing `expressions_can_solve.feature` file in line 652 by adding parentheses around the ! subject.

With the addition of the parentheses all tests pass once again with this version.   It was not a requirement for me to have the previous test pass so I did not get to the bottom of the required fixes to the gramar to make the previous test pass again with the new petite_parser.

TLDR:

`When expression "!@testElement.nullableBoolValue!" is evaluated`
became
`When expression "!(@testElement.nullableBoolValue!)" is evaluated`

The contents of the new `passed_in_old_version.feature` file is included below to highlight the need to possibly fix the gramar for the new petite_parser package to this test passes once again.

`passed_in_old_version.feature` file which contains test which passes in previous version:
```
Feature: Expression
  Tests an expression

  Scenario: Negate Nullable bool
    Given form element is provided
    When expression "!@testElement.nullableBoolValue!" is evaluated
    Then bool expression result is "false"
```
